### PR TITLE
fix: corrigir redirect_uri_mismatch login Google

### DIFF
--- a/config/firebase.js
+++ b/config/firebase.js
@@ -2,24 +2,9 @@ import { initializeApp } from "firebase/app";
 import { getAuth, GoogleAuthProvider } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
 
-function resolveAuthDomain() {
-  const configured = import.meta.env.VITE_FIREBASE_AUTH_DOMAIN;
-
-  if (typeof window === "undefined") {
-    return configured;
-  }
-
-  const host = window.location.hostname;
-  if (host === "localhost" || host === "127.0.0.1") {
-    return configured;
-  }
-
-  return host;
-}
-
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
-  authDomain: resolveAuthDomain(),
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
   projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
   storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
   messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,8 @@
 
 [build.environment]
   NODE_VERSION = "20"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/src/pages/SignIn/index.jsx
+++ b/src/pages/SignIn/index.jsx
@@ -48,6 +48,7 @@ export default function SignIn() {
       setErrorMessage("");
     } catch (err) {
       console.error("Error with Google sign-in:", err.message);
+      setErrorMessage("Google sign-in failed. Please try again.");
     }
   };
 

--- a/src/utils/googleAuth.js
+++ b/src/utils/googleAuth.js
@@ -1,6 +1,16 @@
-import { getRedirectResult, signInWithPopup, signInWithRedirect } from "firebase/auth";
+import {
+  getRedirectResult,
+  signInWithPopup,
+  signInWithRedirect,
+} from "firebase/auth";
 import { auth, googleProvider } from "../../config/firebase";
 import { isStandaloneMode } from "./pwa";
+
+const POPUP_FALLBACK_CODES = new Set([
+  "auth/popup-blocked",
+  "auth/operation-not-supported-in-this-environment",
+  "auth/cancelled-popup-request",
+]);
 
 function isMobileBrowser() {
   if (typeof navigator === "undefined") {
@@ -15,12 +25,20 @@ export async function signInWithGoogle() {
     return signInWithPopup(auth, googleProvider);
   }
 
-  if (isMobileBrowser()) {
+  if (!isMobileBrowser()) {
+    return signInWithPopup(auth, googleProvider);
+  }
+
+  try {
+    return await signInWithPopup(auth, googleProvider);
+  } catch (error) {
+    if (!POPUP_FALLBACK_CODES.has(error.code)) {
+      throw error;
+    }
+
     await signInWithRedirect(auth, googleProvider);
     return null;
   }
-
-  return signInWithPopup(auth, googleProvider);
 }
 
 export async function resolveGoogleRedirect() {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,34 +1,9 @@
-import { defineConfig, loadEnv } from "vite";
-import { writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-function netlifyAuthProxyPlugin(projectId) {
+export default defineConfig(() => {
   return {
-    name: "netlify-auth-proxy",
-    closeBundle() {
-      const lines = [];
-
-      if (projectId) {
-        const firebaseHost = `https://${projectId}.firebaseapp.com`;
-        lines.push(
-          `/__/auth/*  ${firebaseHost}/__/auth/:splat  200!`,
-          `/__/firebase/*  ${firebaseHost}/__/firebase/:splat  200!`
-        );
-      }
-
-      lines.push("/*  /index.html  200");
-      writeFileSync(resolve("public/_redirects"), `${lines.join("\n")}\n`);
-    },
-  };
-}
-
-export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), "");
-  const projectId = env.VITE_FIREBASE_PROJECT_ID;
-
-  return {
-    plugins: [react(), netlifyAuthProxyPlugin(projectId)],
+    plugins: [react()],
     publicDir: "static",
     build: {
       outDir: "public",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problema

Erro **400: redirect_uri_mismatch** ao logar com Google — site e PWA bloqueados.

Causa: PR anterior usou `authDomain = itsmywallet.netlify.app` + redirect no Safari, mas o Google OAuth só tinha registrado o domínio `*.firebaseapp.com`.

## Correção

- `authDomain` volta ao valor do Firebase (`VITE_FIREBASE_AUTH_DOMAIN`)
- PWA: `signInWithPopup`
- Safari mobile: tenta popup primeiro; se bloqueado, redirect com URI do Firebase (já registrado)
- Remove proxy `/__/auth` desnecessário
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1f43-a926-7f13-8d3a-56dc34b6542a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1f43-a926-7f13-8d3a-56dc34b6542a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

